### PR TITLE
add javascript_compressed.js to additional files

### DIFF
--- a/package.js
+++ b/package.js
@@ -11,6 +11,7 @@ Package.onUse(function (api) {
   api.addFiles("lib/blockly/blockly_compressed.js", "client", {bare: true});
   api.addFiles([
     "lib/blockly/blocks_compressed.js",
+    "lib/blockly/javascript_compressed.js",
     "lib/blockly/msg/messages.js"
   ], "client");
   api.export("Blockly");


### PR DESCRIPTION
Hello. Looks like this file contains logic to work with converting from blockly appearance to js code.
Without it Blockly object does not have inner JavaScript object that contains workspaceToCode() method for converting.
